### PR TITLE
Add BackPAN::Index::Release->short_path.

### DIFF
--- a/lib/BackPAN/Index/Release.pm
+++ b/lib/BackPAN/Index/Release.pm
@@ -79,6 +79,13 @@ sub prefix {
     return $self->path;
 }
 
+sub short_path {
+    my $self = shift;
+    my $path = $self->path;
+    $path =~ s{^authors/id/\w/\w{2}/}{};
+    return $path;
+}
+
 1;
 
 __END__
@@ -131,11 +138,29 @@ Returns the date of the release, in UNIX epoch seconds.
 
 Returns the name of the distribution this release belongs to.
 
+This is a L<BackPAN::Index::Dist> object.
+
 =head2 distvname
 
     my $distvname = $release->distvname;
 
 Returns the name of the distribution, hyphen, and version.
+
+=head2 path
+
+    my $path = $release->path;
+
+Returns the full path on CPAN to the release.  This is a
+L<BackPAN::Index::File> object.
+
+=head2 short_path
+
+    my $short_path = $release->short_path;
+
+Returns the path to CPAN without the F<authors/id/X/XY/> part.
+
+For example, F<authors/id/L/LB/LBROCARD/Acme-Colour-0.16.tar.gz> has a
+short_path of F<LBROCARD/Acme-Colour-0.16.tar.gz>.
 
 =head2 filename
 
@@ -148,13 +173,6 @@ Returns the filename of the release, just the file part.
     my $maturity = $release->maturity;
 
 Returns the maturity of the release.
-
-=head2 path
-
-    my $path = $release->path;
-
-Returns the full path on CPAN to the release.  This is a
-L<BackPAN::File> object.
 
 =head2 version
 

--- a/t/release.t
+++ b/t/release.t
@@ -1,0 +1,35 @@
+#!perl
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use Test::More;
+use TestUtils;
+
+my $Backpan;
+subtest "Setting up BackPAN" => sub {
+    $Backpan = new_backpan();
+    isa_ok $Backpan, "BackPAN::Index";
+};
+
+subtest "accessors" => sub {
+    # Specifically pick a release with a subdirectory to test
+    # short_path() edge case.
+    my $release = $Backpan->release("HTTP-Client", 1.43);
+
+    is $release->cpanid,        "LINC";
+    is $release->date,          1124983921;
+    is $release->dist,          "HTTP-Client";
+    isa_ok $release->dist, "BackPAN::Index::Dist";
+    is $release->distvname,     "HTTP-Client-1.43";
+    is $release->path,          "authors/id/L/LI/LINC/HTTP/HTTP-Client-1.43.tar.gz";
+    isa_ok $release->path, "BackPAN::Index::File";
+    is $release->short_path,    "LINC/HTTP/HTTP-Client-1.43.tar.gz";
+    is $release->filename,      "HTTP-Client-1.43.tar.gz";
+    is $release->maturity,      "released";
+    is $release->version,       1.43;
+};
+
+done_testing;


### PR DESCRIPTION
authors/id/X/XY/ is a pecularity of the CPAN file layout.  For other
CPAN tools it's often easier to refer to just the CPANID/PATH part.

Also...
- Fix a doc type BackPAN::File -> BackPAN::Index::File.
- Document that Release->dist is an object.
- Test the Release accessors.

For #27 
