### PR TITLE
Update GitHub and RT URLs

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -41,7 +41,7 @@ my $build = MyBuilder->new(
   meta_merge => {
       resources             => {
           bugtracker        => 'http://rt.cpan.org/Public/Dist/Display.html?Name=BackPAN-Index',
-          repository        => 'http://github.com/acme/parse-backpan-packages',
+          repository        => 'http://github.com/book/BackPAN-Index',
       },
   },
 

--- a/META.json
+++ b/META.json
@@ -103,7 +103,7 @@
          "http://dev.perl.org/licenses/"
       ],
       "repository" : {
-         "url" : "http://github.com/acme/parse-backpan-packages"
+         "url" : "http://github.com/book/BackPAN-Index"
       }
    },
    "version" : "0.42"

--- a/META.yml
+++ b/META.yml
@@ -69,5 +69,5 @@ requires:
 resources:
   bugtracker: http://rt.cpan.org/Public/Dist/Display.html?Name=BackPAN-Index
   license: http://dev.perl.org/licenses/
-  repository: http://github.com/acme/parse-backpan-packages
+  repository: http://github.com/book/BackPAN-Index
 version: 0.42

--- a/README
+++ b/README
@@ -183,7 +183,7 @@ SEE ALSO
     DBIx::Class::ResultSet, BackPAN::Index::File, BackPAN::Index::Release,
     BackPAN::Index::Dist
 
-    Repository: <http://github.com/acme/parse-backpan-packages> Bugs:
     <http://rt.cpan.org/Public/Dist/Display.html?Name=Parse-BACKPAN-Packages
     >
+    Repository: <http://github.com/book/BackPAN-Index>
 

--- a/README
+++ b/README
@@ -183,7 +183,6 @@ SEE ALSO
     DBIx::Class::ResultSet, BackPAN::Index::File, BackPAN::Index::Release,
     BackPAN::Index::Dist
 
-    <http://rt.cpan.org/Public/Dist/Display.html?Name=Parse-BACKPAN-Packages
-    >
     Repository: <http://github.com/book/BackPAN-Index>
+    Bugs: <https://rt.cpan.org/Public/Dist/Display.html?Name=BackPAN-Index>
 

--- a/lib/BackPAN/Index.pm
+++ b/lib/BackPAN/Index.pm
@@ -635,8 +635,8 @@ the same terms as Perl itself.
 L<DBIx::Class::ResultSet>, L<BackPAN::Index::File>,
 L<BackPAN::Index::Release>, L<BackPAN::Index::Dist>
 
-Bugs:        L<http://rt.cpan.org/Public/Dist/Display.html?Name=Parse-BACKPAN-Packages>
 Repository:  L<http://github.com/book/BackPAN-Index>
+Bugs:        L<https://rt.cpan.org/Public/Dist/Display.html?Name=BackPAN-Index>
 
 =cut
 

--- a/lib/BackPAN/Index.pm
+++ b/lib/BackPAN/Index.pm
@@ -635,8 +635,8 @@ the same terms as Perl itself.
 L<DBIx::Class::ResultSet>, L<BackPAN::Index::File>,
 L<BackPAN::Index::Release>, L<BackPAN::Index::Dist>
 
-Repository:  L<http://github.com/acme/parse-backpan-packages>
 Bugs:        L<http://rt.cpan.org/Public/Dist/Display.html?Name=Parse-BACKPAN-Packages>
+Repository:  L<http://github.com/book/BackPAN-Index>
 
 =cut
 


### PR DESCRIPTION
Update the GitHub and RT URLs to their current locations.  Now services such as MetaCPAN can access the relevant data and redirect to the correct sites.

This PR is submitted in the hope that it is useful.  Any questions or comments concerning the PR are more than welcome!