### PR TITLE
Update copyright year to current release year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2012 by Leon Brocard <acme@astray.com> & Michael G Schwern <schwern@pobox.com>.
+This software is Copyright (c) 2009-2012 by Leon Brocard <acme@astray.com> & Michael G Schwern <schwern@pobox.com>.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2012 by Leon Brocard <acme@astray.com> & Michael G Schwern <schwern@pobox.com>.
+This software is Copyright (c) 2009-2012 by Leon Brocard <acme@astray.com> & Michael G Schwern <schwern@pobox.com>.
 
 This is free software, licensed under:
 

--- a/README
+++ b/README
@@ -173,7 +173,7 @@ AUTHOR
     Michael G Schwern <schwern@pobox.com>
 
 COPYRIGHT
-    Copyright 2009, Michael G Schwern
+    Copyright 2009-2012, Michael G Schwern
 
 LICENSE
     This module is free software; you can redistribute it or modify it under

--- a/lib/BackPAN/Index.pm
+++ b/lib/BackPAN/Index.pm
@@ -623,7 +623,7 @@ Michael G Schwern <schwern@pobox.com>
 
 =head1 COPYRIGHT
 
-Copyright 2009, Michael G Schwern
+Copyright 2009-2012, Michael G Schwern
 
 =head1 LICENSE
 

--- a/lib/BackPAN/Index/File.pm
+++ b/lib/BackPAN/Index/File.pm
@@ -151,7 +151,7 @@ Leon Brocard <acme@astray.com>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2009, Leon Brocard
+Copyright (C) 2005-2012, Leon Brocard
 
 This module is free software; you can redistribute it or modify it under
 the same terms as Perl itself.

--- a/lib/BackPAN/Index/Release.pm
+++ b/lib/BackPAN/Index/Release.pm
@@ -175,7 +175,7 @@ Leon Brocard <acme@astray.com> and Michael G Schwern <schwern@pobox.com>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2009, Leon Brocard
+Copyright (C) 2005-2012, Leon Brocard
 
 This module is free software; you can redistribute it or modify it under
 the same terms as Perl itself.

--- a/lib/Parse/BACKPAN/Packages.pm
+++ b/lib/Parse/BACKPAN/Packages.pm
@@ -239,7 +239,7 @@ Leon Brocard <acme@astray.com>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-9, Leon Brocard
+Copyright (C) 2005-2012, Leon Brocard
 
 =head1 LICENSE
 


### PR DESCRIPTION
This bumps the currently-used copyright year to the current release year, which makes sense only in the context of the current release.  There have been commits since and, if the dist is released this year, then the copyright year should be updated to the current year.  Nevertheless, this brings things up to date, so is an improvement.

Some of the copyright statements do not include Michael Schwern, should they be updated to include his name as well?  Should then also the author information also be updated where appropriate?  If so, I can submit a PR for these changes as well.

If you have any questions or comments concerning the PR, please don't hesitate to ask!