### PR TITLE
Purge trailing whitespace

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -292,21 +292,21 @@ Definitions:
 
   - "Package" refers to the collection of files distributed by the Copyright
     Holder, and derivatives of that collection of files created through
-    textual modification. 
+    textual modification.
   - "Standard Version" refers to such a Package if it has not been modified,
     or has been modified in accordance with the wishes of the Copyright
-    Holder. 
+    Holder.
   - "Copyright Holder" is whoever is named in the copyright or copyrights for
-    the package. 
+    the package.
   - "You" is you, if you're thinking about copying or distributing this Package.
   - "Reasonable copying fee" is whatever you can justify on the basis of media
     cost, duplication charges, time of people involved, and so on. (You will
     not be required to justify it to the Copyright Holder, but only to the
-    computing community at large as a market that must bear the fee.) 
+    computing community at large as a market that must bear the fee.)
   - "Freely Available" means that no fee is charged for the item itself, though
     there may be fees involved in handling the item. It also means that
     recipients of the item may redistribute it under the same conditions they
-    received it. 
+    received it.
 
 1. You may make and give away verbatim copies of the source form of the
 Standard Version of this Package without restriction, provided that you

--- a/lib/BackPAN/Index/Database.pm
+++ b/lib/BackPAN/Index/Database.pm
@@ -48,7 +48,7 @@ has schema =>
 
 # If you change the schema, be sure to run ./Build result_classes
 # to update the result classes.
-# 
+#
 # This is denormalized for performance, its read-only anyway
 has create_tables_sql =>
   is		=> 'ro',

--- a/lib/BackPAN/Index/IndexFile.pm
+++ b/lib/BackPAN/Index/IndexFile.pm
@@ -80,7 +80,7 @@ sub extract_index_file {
 
 sub get_index {
     my $self = shift;
-    
+
     my $url = $self->index_url;
 
     $self->_log("Fetching BackPAN index from $url...");

--- a/lib/Parse/BACKPAN/Packages.pm
+++ b/lib/Parse/BACKPAN/Packages.pm
@@ -62,7 +62,7 @@ sub files {
     while( my $file = $rs->next ) {
         $files{$file->path} = $file;
     }
-    
+
     return \%files;
 }
 
@@ -149,7 +149,7 @@ Parse::BACKPAN::Packages - Provide an index of BACKPAN
 
   # see Parse::BACKPAN::Packages::Release
   my @acme_colours = $p->releases("Acme-Colour");
-  
+
   my @authors = $p->authors;
   my @acmes = $p->distributions_by('LBROCARD');
 


### PR DESCRIPTION
Some projects are picky about trailing whitespace (e.g. the Linux kernel) and others aren't.  This PR is submitted in the hope that it is useful, however if you don't wish to have it included, then I'm happy if it's closed without being merged.