### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: perl
+
+perl:
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm --installdeps --notest . || { cat ~/.cpanm/build.log ; false ; }


### PR DESCRIPTION
[Travis-CI](https://travis-ci.org) is a free (for open source projects) service which one can use to build and test one's software.  This PR adds a first-cut configuration file (the tests pass on the currently configured Perl versions) which can be extended later as required.  It doesn't run the `AUTHOR_TESTING` tests yet since they don't pass the POD coverage tests.