### PR TITLE
Fix perlcritic errors

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -13,6 +13,7 @@ my $build = MyBuilder->new(
 
   requires           => {
     'App::Cache'            => '0.37',
+    'Class::Load'           => '0',
     'CPAN::DistnameInfo'    => '0.09',
     CLASS                   => '1.00',
     'LWP::Simple'           => '0',

--- a/lib/BackPAN/Index.pm
+++ b/lib/BackPAN/Index.pm
@@ -191,7 +191,7 @@ sub _populate_database {
 
     my %dists;
     my %files;
-    open my $fh, $self->backpan_index->index_file;
+    open my $fh, "<", $self->backpan_index->index_file;
     while( my $line = <$fh> ) {
         my %release;
         chomp $line;

--- a/t/pod.t
+++ b/t/pod.t
@@ -4,7 +4,10 @@ use warnings;
 use strict;
 
 use Test::More;
-eval "use Test::Pod 1.14";
+use Class::Load qw(try_load_class);
+
 plan skip_all => "Author test" unless $ENV{AUTHOR_TESTING};
-plan skip_all => "Test::Pod 1.14 required for testing POD: $@" if $@;
-all_pod_files_ok();
+my $min_tp = 1.14;
+try_load_class('Test::Pod', {-version => $min_tp})
+     or plan skip_all => "Test::Pod $min_tp required for testing POD";
+ Test::Pod::all_pod_files_ok();

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,5 +1,8 @@
 #!perl -T
 
+use warnings;
+use strict;
+
 use Test::More;
 eval "use Test::Pod 1.14";
 plan skip_all => "Author test" unless $ENV{AUTHOR_TESTING};

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -1,5 +1,8 @@
 #!perl -T
 
+use warnings;
+use strict;
+
 use Test::More;
 eval "use Test::Pod::Coverage 1.04";
 plan skip_all => "Author test" unless $ENV{AUTHOR_TESTING};

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -4,10 +4,13 @@ use warnings;
 use strict;
 
 use Test::More;
-eval "use Test::Pod::Coverage 1.04";
+use Class::Load qw(try_load_class);
+
 plan skip_all => "Author test" unless $ENV{AUTHOR_TESTING};
-plan skip_all => "Test::Pod::Coverage 1.04 required for testing POD coverage" if $@;
-all_pod_coverage_ok(
+my $min_tpc = 1.04;
+try_load_class('Test::Pod::Coverage', {-version => $min_tpc})
+     or plan skip_all => "Test::Pod::Coverage $min_tpc required for testing POD coverage";
+Test::Pod::Coverage::all_pod_coverage_ok(
     # BackPAN::Index::File/Release::prefix() is for backwards compat with PBP
     { trustme => [qr/^prefix$/, qr/^data_methods$/] }
 );


### PR DESCRIPTION
These commits fix the most basic `perlcritic` issues in the dist (at severity level 5).  The last commit avoids the expression form of `eval` in the POD-related tests, however adds a new dependency.  If this change isn't desired, please cherry pick as necessary.  If you wish for improvements or alterations to the PR as it stands, please let me know and I'll make the necessary changes and resubmit.