### PR TITLE
Specify sequence of tests and parallelism

### DIFF
--- a/testrules.yml
+++ b/testrules.yml
@@ -1,0 +1,7 @@
+---
+# This test suite needs the t/00* files to be run first, then it can run in parallel
+seq:
+    - seq: t/00*.t
+    - par:
+        - t/*.t
+        - xt/*.t


### PR DESCRIPTION
Without this change, running the test suite in parallel fails, because
t/00setup.t needs to finish before the other tests start.

    prove -j 12 -bl