### PR TITLE
Make tests parallel safe

### DIFF
--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -1,0 +1,3 @@
+seq:
+  - seq: t/00setup.t
+  - par: **


### PR DESCRIPTION
If running tests in parallel, they often fail because t/00setup.t needs to complete before other tests:

    $ HARNESS_OPTIONS=j4 BACKPAN_INDEX_TEST_NO_INTERNET=1 ./Build test
    ===(       4;0   1/11  1/4  1/?   1/84 )================================# Fetching the BackPAN index and creating the database. This may take a while.
    DBD::SQLite::st execute failed: UNIQUE constraint failed: files.path at /tmp/BackPAN-Index/blib/lib/BackPAN/Index.pm line 217, <$_[...]> line 2.
    DBD::SQLite::st execute failed: UNIQUE constraint failed: files.path at /tmp/BackPAN-Index/blib/lib/BackPAN/Index.pm line 217, <$_[...]> line 2.
    Issuing rollback() due to DESTROY without explicit disconnect() of DBD::SQLite::db handle dbname=/tmp/BackPAN-Index/t/cache/backpan.sqlite at /tmp/BackPAN-Index/blib/lib/BackPAN/Index.pm line 217.
    # Looks like your test exited with 2 just after 1.
    t/00setup.t ........................ Dubious, test returned 2 (wstat 512, 0x200)
    Failed 3/4 subtests

This patch adds TAP::Harness test rules so that t/00setup.t is run always first.